### PR TITLE
Add on_delete option to belongs_to

### DIFF
--- a/db/migrations/003_create_comments.cr
+++ b/db/migrations/003_create_comments.cr
@@ -1,7 +1,7 @@
 class CreateComments::V20171117153222 < LuckyMigrator::Migration::V1
   def migrate
     create :comments do
-      belongs_to User, references: :users
+      belongs_to User, references: :users, on_delete: :cascade
       add author_id : Int64
     end
 

--- a/spec/create_table_statement_spec.cr
+++ b/spec/create_table_statement_spec.cr
@@ -72,7 +72,7 @@ describe LuckyMigrator::CreateTableStatement do
   describe "associations" do
     it "can create associations" do
       built = LuckyMigrator::CreateTableStatement.new(:comments).build do
-        belongs_to User
+        belongs_to User, on_delete: :cascade
         belongs_to Post?
         belongs_to CategoryLabel, references: :custom_table
       end
@@ -82,7 +82,7 @@ describe LuckyMigrator::CreateTableStatement do
         id serial PRIMARY KEY,
         created_at timestamptz NOT NULL,
         updated_at timestamptz NOT NULL,
-        user_id bigint NOT NULL REFERENCES users,
+        user_id bigint NOT NULL REFERENCES users ON DELETE CASCADE,
         post_id bigint REFERENCES posts,
         category_label_id bigint NOT NULL REFERENCES custom_table);
       SQL
@@ -90,6 +90,14 @@ describe LuckyMigrator::CreateTableStatement do
       built.statements[1].should eq "CREATE INDEX comments_user_id_index ON comments USING btree (user_id);"
       built.statements[2].should eq "CREATE INDEX comments_post_id_index ON comments USING btree (post_id);"
       built.statements[3].should eq "CREATE INDEX comments_category_label_id_index ON comments USING btree (category_label_id);"
+    end
+
+    it "raises error when on_delete strategy is invalid" do
+      expect_raises Exception, "on_delete: :cascad is not supported. Please use :do_nothing, :cascade, :restrict, or :nullify" do
+        LuckyMigrator::CreateTableStatement.new(:users).build do
+          belongs_to User, on_delete: :cascad
+        end
+      end
     end
   end
 end

--- a/src/lucky_migrator/create_table_statement.cr
+++ b/src/lucky_migrator/create_table_statement.cr
@@ -1,6 +1,4 @@
 class LuckyMigrator::CreateTableStatement
-  ALLOWED_ON_DELETE_STRATEGIES = %i[cascade restrict nullify]
-
   private getter rows = [] of String
   private getter index_statements = [] of String
 
@@ -157,7 +155,7 @@ class LuckyMigrator::CreateTableStatement
       ""
     elsif on_delete == :do_nothing
       " REFERENCES #{table_name}"
-    elsif ALLOWED_ON_DELETE_STRATEGIES.includes?(on_delete)
+    elsif CreateForeignKeyStatement::ALLOWED_ON_DELETE_STRATEGIES.includes?(on_delete)
       " REFERENCES #{table_name}" + " ON DELETE " + "#{on_delete}".upcase
     else
       raise "on_delete: :#{on_delete} is not supported. Please use :do_nothing, :cascade, :restrict, or :nullify"


### PR DESCRIPTION
Related to #31.

This duplicates the `ALLOWED_ON_DELETE_STRATEGIES` const from the CreateForeignKeyStatement class. I'm not sure how to refactor this, maybe if there was a helper class that holds these constants. What do you think?