### PR TITLE
Remove index

### DIFF
--- a/db/migrations/002_alter_users.cr
+++ b/db/migrations/002_alter_users.cr
@@ -5,6 +5,8 @@ class AlterUsers::V002 < LuckyMigrator::Migration::V1
       add name : String
       add nickname : String?
     end
+
+    drop_index :users, :last_name
   end
 
   def rollback

--- a/db/migrations/002_alter_users.cr
+++ b/db/migrations/002_alter_users.cr
@@ -6,7 +6,7 @@ class AlterUsers::V002 < LuckyMigrator::Migration::V1
       add nickname : String?
     end
 
-    drop_index :users, :last_name
+    drop_index :users, :last_name, if_exists: true, on_delete: :cascade
   end
 
   def rollback

--- a/spec/drop_index_statement_spec.cr
+++ b/spec/drop_index_statement_spec.cr
@@ -1,0 +1,8 @@
+require "./spec_helper"
+
+describe LuckyMigrator::DropIndexStatement do
+  it "generates correct sql" do
+    statement = LuckyMigrator::DropIndexStatement.new(:users, :email).build
+    statement.should eq "DROP INDEX users_email_index;"
+  end
+end

--- a/spec/drop_index_statement_spec.cr
+++ b/spec/drop_index_statement_spec.cr
@@ -2,7 +2,7 @@ require "./spec_helper"
 
 describe LuckyMigrator::DropIndexStatement do
   it "generates correct sql" do
-    statement = LuckyMigrator::DropIndexStatement.new(:users, :email).build
-    statement.should eq "DROP INDEX users_email_index;"
+    statement = LuckyMigrator::DropIndexStatement.new(:users, :email, on_delete: :cascade, if_exists: true).build
+    statement.should eq "DROP INDEX IF EXISTS users_email_index CASCADE;"
   end
 end

--- a/src/lucky_migrator/create_index_statement.cr
+++ b/src/lucky_migrator/create_index_statement.cr
@@ -4,7 +4,7 @@
 # ### Usage
 #
 # ```
-# IndexDefinition.new(:users, column: :email, using: :btree, unique: true).build
+# CreateIndexStatement.new(:users, column: :email, using: :btree, unique: true).build
 # # => "CREATE UNIQUE INDEX users_email_index ON users USING btree (email);"
 # ```
 class LuckyMigrator::CreateIndexStatement

--- a/src/lucky_migrator/drop_index_statement.cr
+++ b/src/lucky_migrator/drop_index_statement.cr
@@ -1,0 +1,21 @@
+# Builds an SQL statement for dropping an index by inferring it's name using table name and column.
+#
+# ### Usage
+#
+# ```
+# DropIndexStatement.new(:users, :email).build
+# # => "DROP INDEX users_email_index;"
+# ```
+class LuckyMigrator::DropIndexStatement
+  ALLOWED_INDEX_TYPES = %w[btree]
+
+  def initialize(@table : Symbol, @column : Symbol)
+  end
+
+  def build
+    String.build do |index|
+      index << "DROP"
+      index << " INDEX #{@table}_#{@column}_index;"
+    end
+  end
+end

--- a/src/lucky_migrator/drop_index_statement.cr
+++ b/src/lucky_migrator/drop_index_statement.cr
@@ -27,7 +27,7 @@ class LuckyMigrator::DropIndexStatement
     elsif ALLOWED_ON_DELETE_STRATEGIES.includes?(on_delete)
       " #{on_delete};".upcase
     else
-      raise "on_delete: :#{on_delete} is not supported. Please use :do_nothing, :cascade of :restrict"
+      raise "on_delete: :#{on_delete} is not supported. Please use :do_nothing, :cascade or :restrict"
     end
   end
 end

--- a/src/lucky_migrator/statement_helpers.cr
+++ b/src/lucky_migrator/statement_helpers.cr
@@ -29,7 +29,7 @@ module LuckyMigrator::StatementHelpers
     execute CreateIndexStatement.new(table_name, column, using, unique).build
   end
 
-  def drop_index(table_name : Symbol, column : Symbol)
-    execute LuckyMigrator::DropIndexStatement.new(table_name, column).build
+  def drop_index(table_name : Symbol, column : Symbol, if_exists = false, on_delete = :do_nothing)
+    execute LuckyMigrator::DropIndexStatement.new(table_name, column, if_exists, on_delete).build
   end
 end

--- a/src/lucky_migrator/statement_helpers.cr
+++ b/src/lucky_migrator/statement_helpers.cr
@@ -28,4 +28,8 @@ module LuckyMigrator::StatementHelpers
   def create_index(table_name : Symbol, column : Symbol, unique = false, using = :btree)
     execute CreateIndexStatement.new(table_name, column, using, unique).build
   end
+
+  def drop_index(table_name : Symbol, column : Symbol)
+    execute LuckyMigrator::DropIndexStatement.new(table_name, column).build
+  end
 end


### PR DESCRIPTION
Closes #21.

A couple things:
I renamed the class and helper method to drop_index to be consistent with the `DROP INDEX` statement that's generated. I thought that would be clearer, what do you think?

I also added an option for adding the `IF EXISTS` parameter, and I set it to false by default. I thought it might be better to show the user the error so they can remove redundant statements.

And I added the on_delete parameter, because some dba pro might need it.
