### PR TITLE
Reverse migration order on rollback_all

### DIFF
--- a/src/lucky_migrator/runner.cr
+++ b/src/lucky_migrator/runner.cr
@@ -42,7 +42,7 @@ class LuckyMigrator::Runner
 
   def rollback_all
     setup_migration_tracking_tables
-    migrated_migrations.each &.new.down
+    migrated_migrations.reverse.each &.new.down
   end
 
   def rollback_one


### PR DESCRIPTION
Closes #38.

Calls reverse on migrations: `migrated_migrations.reverse.each &.new.down`